### PR TITLE
Add option to provide intent action and data uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # sevensky-cordova-plugin-startactivity
 Cordova plugin startActivity for android devices 
 
-Feature :
+Features :
 + StartActivity 
 + PutExtra string format
++ Intent action
++ Intent data URI
 
 Install :
 
@@ -18,5 +20,5 @@ Usage :
             var obj = new Object();
             obj.name = "Ahmad";
             obj.family = "Aghazadeh";
-            intentPlugin.startActivity("com.xomorod.fastbook", "PurchaseActivity", JSON.stringify(obj));
+            intentPlugin.startActivity("com.xomorod.fastbook", "PurchaseActivity", null, null, JSON.stringify(obj));
         }

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="sevensky-cordova-plugin-intent"
-    version="1.0.6">
+    version="1.1.0">
     <name>AndroidIntent</name>
     <description>Sevensky Plugins</description>
     <license>MIT License</license>

--- a/src/android/IntentPlugin.java
+++ b/src/android/IntentPlugin.java
@@ -2,7 +2,9 @@ package sevensky.cordova.plugins;
 
 import android.content.ComponentName;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -14,33 +16,62 @@ import org.json.JSONObject;
  * Created by Ahmad on 2/3/2017.
  */
 public class IntentPlugin extends CordovaPlugin {
-
-
     @Override
-    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
+      try {
         if (action.equals("startActivity")) {
-            String appName = args.getString(0);
+            String packageName = args.getString(0);
             String activityName = args.getString(1);
-            JSONObject jsonObject=new JSONObject(args.getString(2));
-            Bundle bundle=new Bundle();
-            for(int i = 0; i<jsonObject.names().length(); i++){
-                bundle.putString(jsonObject.names().getString(i) ,
-                        jsonObject.get(jsonObject.names().getString(i)).toString());
+            String dataUri = args.getString(2);
+            String androidAction = args.getString(3);
+            JSONObject jsonObject = null;
+
+            try {
+              jsonObject = new JSONObject(args.getString(4));
+            } catch(JSONException e) {
+                Log.w("IntentPlugin", "Unable to get json object");
             }
-            this.startActivity(appName,activityName, callbackContext,bundle);
+
+            Bundle bundle = new Bundle();
+
+            if (jsonObject != null && jsonObject.names() != null) {
+              for(int i = 0; i<jsonObject.names().length(); i++){
+                  bundle.putString(jsonObject.names().getString(i),
+                          jsonObject.get(jsonObject.names().getString(i)).toString());
+              }
+            }
+
+            this.startActivity(packageName, activityName, callbackContext, dataUri, androidAction, bundle);
+
             return true;
         }
+      } catch(JSONException e) {
+          Log.w("IntentPlugin", "Unable to start activity");
+      }
+
         return false;
     }
 
+    private void startActivity(String packageName, String activityName, CallbackContext callbackContext, String dataUri, String action, Bundle bundle) {
+        if (packageName != null && packageName.length() > 0) {
+            if (activityName.startsWith(".")) {
+                activityName = packageName + activityName;
+            }
 
-    private void startActivity(String appName,String activityName, CallbackContext callbackContext,Bundle bundle) {
-        if (appName != null && appName.length() > 0) {
             Intent intent = new Intent();
             intent.putExtras(bundle);
-            intent.setComponent(new ComponentName(appName, appName+"."+activityName));
+            intent.setComponent(new ComponentName(packageName, activityName));
+
+            if (dataUri != null) {
+      		      intent.setData(Uri.parse(dataUri));
+      	    }
+
+            if (action != null) {
+                intent.setAction(action);
+            }
+
             this.cordova.getActivity().startActivity(intent);
-            callbackContext.success(appName+"."+activityName);
+            callbackContext.success(activityName);
         } else {
             callbackContext.error("Expected one non-empty string argument.");
         }

--- a/www/intentPlugin.js
+++ b/www/intentPlugin.js
@@ -4,8 +4,8 @@ function IntentPlugin() {
 
 }
 
-IntentPlugin.prototype.startActivity = function (packageName,activitiName,bundle) {
-    exec(function (res) { }, function (err) { }, "IntentPlugin", "startActivity", [packageName,activitiName,bundle]);
+IntentPlugin.prototype.startActivity = function (packageName, activityName, dataUri, action, bundle) {
+    exec(function (res) { }, function (err) { }, "IntentPlugin", "startActivity", [packageName, activityName, dataUri, action, bundle]);
 }
 
 module.exports = new IntentPlugin();


### PR DESCRIPTION
When invoking an activity it is possible to provide an Android action
and data uri. Also, when providing the package name and Activity name
it is now possible to provide a fully qualified class name. When the
name of the Activity is prefixed with a '.'; then the Activity name
is automatically prefixed with the package name.